### PR TITLE
Adding more auth value for postgres

### DIFF
--- a/postgres-pod.yml
+++ b/postgres-pod.yml
@@ -11,7 +11,11 @@ spec:
   - name: postgres-pod
     image: postgres:9.4
     env:
-    - name: POSTGRES_PASSWORD
-      value: mysecretpassword
+      - name: POSTGRES_USER
+        value: postgres
+      - name: POSTGRES_PASSWORD
+        value: postgres
+      - name: POSTGRES_HOST_AUTH_METHOD
+        value: trust
     ports:
     - containerPort: 5432


### PR DESCRIPTION
trying ot resolve an error as follows:
kubectl logs postgres-pod:
OG:  received fast shutdown request
LOG:  aborting any active transactions
LOG:  autovacuum launcher shutting down
LOG:  shutting down
waiting for server to shut down....LOG:  database system is shut down
 done
server stopped
PostgreSQL init process complete; ready for start up.
LOG:  database system was shut down at 2020-03-21 22:02:22 UTC
LOG:  MultiXact member wraparound protections are now enabled
LOG:  database system is ready to accept connections
LOG:  autovacuum launcher started
FATAL:  password authentication failed for user "postgres"
DETAIL:  Connection matched pg_hba.conf line 95: "host all all all md5"
FATAL:  password authentication failed for user "postgres"
DETAIL:  Connection matched pg_hba.conf line 95: "host all all all md5"